### PR TITLE
Make cat1 site public

### DIFF
--- a/k8s/charts/cat1-balance/values.yaml
+++ b/k8s/charts/cat1-balance/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 3
 
 image: ghcr.io/chia-network/cat1-balance
 


### PR DESCRIPTION
Should not be merged until Tuesday after EOL block height.

Before merging, make sure the final CSV is uploaded to backblaze correctly (eg. correct file name/path in the bucket, valid to the EOL block height.)