### PR TITLE
Remove unused  label from k8s Service

### DIFF
--- a/k8s/charts/cat1-balance/templates/service.yaml
+++ b/k8s/charts/cat1-balance/templates/service.yaml
@@ -8,7 +8,6 @@ metadata:
   {{- end }}
   labels:
     {{- include "cat1-balance.labels" . | nindent 4 }}
-    prometheus: application-metrics
 spec:
   type:  {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
This label tells a Prometheus ServiceMonitor to scrape the metrics endpoint on this service for metrics. The web application doesn't actually have a metrics endpoint, so Prometheus just shows a bunch of permanently down targets. This went unnoticed because this cluster didn't have a prometheus instance to try to scrape from this until earlier this morning. Just noticed it now.

The effect of not merging this is just a few unnecessarily "down" targets in the Prometheus UI.